### PR TITLE
Use dependency injection to provide es connection

### DIFF
--- a/book_search/api/search.py
+++ b/book_search/api/search.py
@@ -1,10 +1,12 @@
 from typing import List
 
+from elasticsearch import AsyncElasticsearch
 from fastapi import APIRouter, Depends, Query
 from starlette.requests import Request
 
 from .. import models
 from ..app_settings import Settings, get_settings
+from ..es import get_es
 from ..es.search import search_es
 
 search_router = APIRouter()
@@ -14,6 +16,7 @@ search_router = APIRouter()
 async def search(
     request: Request,
     settings: Settings = Depends(get_settings),  # noqa: B008
+    es_client: AsyncElasticsearch = Depends(get_es),  # noqa: B008
     q: str = Query(None, description="Free text query string."),  # noqa: B008
     tags: List[str] = Query([], description="List of tags slugs."),  # noqa: B008
     year: int = Query(None, description="Filter by publication year."),  # noqa: B008
@@ -22,5 +25,5 @@ async def search(
     """
     Search ES data according to the provided filters.
     """
-    results, total = await search_es(settings, q, year, tags, size)
+    results, total = await search_es(settings, es_client, q, year, tags, size)
     return {"results": results, "count": total}

--- a/book_search/es/__init__.py
+++ b/book_search/es/__init__.py
@@ -2,8 +2,9 @@ from typing import Union
 
 from elasticsearch import AsyncElasticsearch, Elasticsearch
 from elasticsearch_dsl.connections import add_connection
+from fastapi import Depends
 
-from ..app_settings import Settings
+from ..app_settings import Settings, get_settings
 
 
 def init_es(settings: Settings, use_async: bool = True) -> Union[AsyncElasticsearch, Elasticsearch]:
@@ -14,3 +15,18 @@ def init_es(settings: Settings, use_async: bool = True) -> Union[AsyncElasticsea
         client = Elasticsearch([settings.ES_HOST])
         add_connection("default", client)
         return client
+
+
+async def get_es(
+    settings=Depends(get_settings), use_async=True  # noqa: B008
+) -> Union[AsyncElasticsearch, Elasticsearch]:
+    """
+    Get an elastic search client.
+
+    The client connection is closed after each request.
+    """
+    try:
+        es_client = init_es(settings, use_async=use_async)
+        yield es_client
+    finally:
+        await es_client.close()

--- a/book_search/es/search.py
+++ b/book_search/es/search.py
@@ -1,14 +1,16 @@
 from typing import List, Tuple
 
+from elasticsearch import AsyncElasticsearch
+
 from ..app_settings import Settings
-from . import init_es
 from .documents import Book
 
 
-async def search_es(settings: Settings, q: str, year: int, tags: List[str], size: int) -> Tuple[List[Book], int]:
+async def search_es(
+    settings: Settings, es_client: AsyncElasticsearch, q: str, year: int, tags: List[str], size: int
+) -> Tuple[List[Book], int]:
     """Build the ES query and run it, returning results and total count."""
-    client = init_es(settings, use_async=True)
-    query_dict = {"query": {"bool": {"must": []}}}
+    query_dict = {"bool": {"must": []}}
     if q:
         text_query = {
             "bool": {
@@ -18,17 +20,16 @@ async def search_es(settings: Settings, q: str, year: int, tags: List[str], size
                 ]
             }
         }
-        query_dict["query"]["bool"]["must"].append(text_query)
+        query_dict["bool"]["must"].append(text_query)
     if year:
-        query_dict["query"]["bool"]["must"].append({"match": {"original_publication_year": year}})
+        query_dict["bool"]["must"].append({"match": {"original_publication_year": year}})
     if tags:
         tags_query = {
             "bool": {"should": [{"nested": {"path": "tags", "query": {"match": {"tags.slug": tag}}}} for tag in tags]}
         }
-        query_dict["query"]["bool"]["must"].append(tags_query)
+        query_dict["bool"]["must"].append(tags_query)
 
-    response = await client.search(index="book", query=query_dict["query"], size=size)
+    response = await es_client.search(index="book", query=query_dict, size=size)
     results = [row["_source"] for row in response["hits"]["hits"]]
     total = response["hits"]["total"]["value"]
-    await client.close()
     return results, total

--- a/changes/20220605.feature
+++ b/changes/20220605.feature
@@ -1,0 +1,1 @@
+Use dependency injection to provide es connection

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -8,18 +8,18 @@ from book_search.main import app
 
 
 def test_search_basic_sync(load_books):
-    client = TestClient(app)
-    url = app.url_path_for("search")
-    params = urlencode({"q": "Susan Collins"})
-    response = client.get(f"{url}?{params}")
-    assert response.status_code == 200
-    data = response.json()
-    assert data["results"]
-    assert data["count"] == 3
-    assert [row["book_id"] for row in data["results"]] == [1, 17, 20]
-    for row in data["results"]:
-        assert row["title"]
-        assert row["isbn13"]
+    with TestClient(app) as client:
+        url = app.url_path_for("search")
+        params = urlencode({"q": "Susan Collins"})
+        response = client.get(f"{url}?{params}")
+        assert response.status_code == 200
+        data = response.json()
+        assert data["results"]
+        assert data["count"] == 3
+        assert [row["book_id"] for row in data["results"]] == [1, 17, 20]
+        for row in data["results"]:
+            assert row["title"]
+            assert row["isbn13"]
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
# Description

Using a dependecy injection allows a cleaner connection handling: by using yield in the dependency function, we can close the connection automatically when the path operation returns the response

Optimal solution would be to initialize the connection on startup, to avoid recreating the connection on each request, but there is some issues with tests in this case

# Checklist

* [x] I have read the [contribution guide](https://nephila-app.readthedocs.io/en/latest/contributing.html)
* [x] Code lint checked via `inv lint`
* [x] ``changes`` file included (see [docs](https://nephila-app.readthedocs.io/en/latest/contributing.html#pull-request-guidelines))
* [x] Usage documentation added in case of new features
* [x] Tests added
